### PR TITLE
Fixes broken link to fairsharing.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -773,7 +773,7 @@ In the highly unlikely event that Zenodo will have to close operations, we guara
   <p>Is Zenodo certified?</p>
 
 </h5>
-<p>Zenodo is recommended by <a href="FAIRsharing.org">FAIRsharing.org</a>. We also have self-assessments for the FAIR principles and Plan S in our <a href="https://about.zenodo.org/principles/">Principles page</a>.</p>
+<p>Zenodo is recommended by <a href="https://FAIRsharing.org">FAIRsharing.org</a>. We also have self-assessments for the FAIR principles and Plan S in our <a href="https://about.zenodo.org/principles/">Principles page</a>.</p>
 
         
       


### PR DESCRIPTION
From the commit log, I am pretty sure a PR is the wrong mechanism to suggest this but this was the most convenient way to point out th exact location.